### PR TITLE
Don't disable "sppsvc"

### DIFF
--- a/Windows_8.1_Debloat.ps1
+++ b/Windows_8.1_Debloat.ps1
@@ -59,7 +59,7 @@ $Job = Start-Job -ScriptBlock {
     $List = @(
         # Default Windows Services
         'workfolderssvc','W32Time','WSService','WSearch','WinRM','WMPNetworkSvc','lfsvc','MpsSvc','WbioSrvc'
-        'VSS','TabletInputService','Themes','SysMain','svsvc','sppsvc','SCardSvr','ScDeviceEnum','SCPolicySvc'
+        'VSS','TabletInputService','Themes','SysMain','svsvc','SCardSvr','ScDeviceEnum','SCPolicySvc'
         'LanmanServer','SensrSvc','wscsvc','RemoteRegistry','QWAVE','PcaSvc','wercplsupport','PrintNotify'
         'Spooler','pla','defragsvc','CscService','NcaSvc','NcbService','smphost','swprv','MsKeyboardFilter'
         'edgeupdatem','edgeupdate','MicrosoftEdgeElevationService','wlidsvc','lltdsvc','iphlpsvc','IEEtwCollectorService'


### PR DESCRIPTION
"sppsvc" is an important service that keeps Windows 8.1 activated, at least for me. Disabling "sppsvc" has caused my Windows 8.1 installation to appear unactivated and prompt me to "Activate Windows".

My key is authentic and lifetime, it's embedded within my BIOS, and it worked after I re-enabled the "sppsvc" service using the Registry Editor. I couldn't use the services panel, because enabling the service got locked behind an admin requirement. Restarting Windows after that displayed it as activated.

Was this script meant for Windows 8 VMs, maybe?